### PR TITLE
pass MFA option data to the support bot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module github.com/silinternational/idp-id-broker-search
 
 go 1.18
 
-require github.com/aws/aws-lambda-go v1.38.0
+require (
+	github.com/aws/aws-lambda-go v1.38.0
+	github.com/stretchr/testify v1.7.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,14 @@
 github.com/aws/aws-lambda-go v1.38.0 h1:4CUdxGzvuQp0o8Zh7KtupB9XvCiiY8yKqJtzco+gsDw=
 github.com/aws/aws-lambda-go v1.38.0/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -3,13 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/silinternational/idp-id-broker-search/shared"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/aws/aws-lambda-go/lambda"
+
+	"github.com/silinternational/idp-id-broker-search/shared"
 )
 
 type BrokerConfig struct {
@@ -77,7 +79,7 @@ func search(config BrokerConfig, query string) ([]shared.User, error) {
 
 	var results []shared.User
 
-	bodyText, err := ioutil.ReadAll(resp.Body)
+	bodyText, err := io.ReadAll(resp.Body)
 	err = json.Unmarshal(bodyText, &results)
 	if err != nil {
 		log.Println("JSON parse error:", err)

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func patchMfaCounts(mfaOptions []shared.MfaOption) {
 	for i, o := range mfaOptions {
 		switch o.Type {
 		case shared.MfaTypeBackupCode:
-			data, _ := o.Data.(map[string]interface{})
+			data, _ := o.Data.(map[string]any)
 			if o.Count == 0 && data["count"] != 0 {
 				count, _ := data["count"].(float64)
 				mfaOptions[i].Count = int(count)

--- a/main_test.go
+++ b/main_test.go
@@ -259,26 +259,10 @@ func fakeUser(userID int) shared.User {
 			Hide:           "no",
 			RequireMFA:     "no",
 			Member:         []string{"dev"},
-			Mfa: struct {
-				Prompt  string `json:"prompt"`
-				Add     string `json:"add"`
-				Options []struct {
-					ID          int    `json:"id"`
-					Type        string `json:"type"`
-					Label       string `json:"label"`
-					CreatedUtc  string `json:"created_utc"`
-					LastUsedUtc string `json:"last_used_utc"`
-				} `json:"options"`
-			}{
+			Mfa: shared.Mfa{
 				Prompt: "no",
 				Add:    "no",
-				Options: []struct {
-					ID          int    `json:"id"`
-					Type        string `json:"type"`
-					Label       string `json:"label"`
-					CreatedUtc  string `json:"created_utc"`
-					LastUsedUtc string `json:"last_used_utc"`
-				}{
+				Options: []shared.MfaOption{
 					{
 						ID:          1,
 						Type:        "webauthn",
@@ -302,29 +286,13 @@ func fakeUser(userID int) shared.User {
 					},
 				},
 			},
-			Password: struct {
-				CreatedUtc string `json:"created_utc"`
-				ExpiresOn  string `json:"expires_on"`
-			}{
+			Password: shared.Password{
 				CreatedUtc: "",
 				ExpiresOn:  "",
 			},
-			Method: struct {
-				Add     string `json:"add"`
-				Options []struct {
-					ID       string `json:"id"`
-					Value    string `json:"value"`
-					Verified bool   `json:"verified"`
-					Created  string `json:"created"`
-				} `json:"options"`
-			}{
+			Method: shared.Method{
 				Add: "no",
-				Options: []struct {
-					ID       string `json:"id"`
-					Value    string `json:"value"`
-					Verified bool   `json:"verified"`
-					Created  string `json:"created"`
-				}{
+				Options: []shared.MethodOption{
 					{
 						ID:    "_BC9GEpZeIqbXoBiLdhrRAwkNUlz7scg",
 						Value: "l***_v*****e@e******.c**", Verified: false, Created: "2024-04-04T19:30:34Z",

--- a/main_test.go
+++ b/main_test.go
@@ -164,6 +164,7 @@ func Test_search(t *testing.T) {
 			require.Equal(t, tt.want[0].EmployeeID, got[0].EmployeeID)
 			require.Equal(t, tt.want[0].DisplayName, got[0].DisplayName)
 			require.Equal(t, tt.want[0].Mfa.Options[0].Label, got[0].Mfa.Options[0].Label)
+			require.Equal(t, tt.want[0].Mfa.Options[0].Count, got[0].Mfa.Options[0].Count)
 			require.Equal(t, tt.want[0].Method.Options[0].Value, got[0].Method.Options[0].Value)
 		})
 	}
@@ -282,6 +283,7 @@ func fakeUser(userID int) shared.User {
 						Label:       "Yubikey",
 						CreatedUtc:  "2024-04-03T18:27:44Z",
 						LastUsedUtc: "2024-04-04T12:27:45Z",
+						Count:       1,
 						Data: []shared.WebauthnData{
 							{
 								ID:          1,
@@ -305,6 +307,7 @@ func fakeUser(userID int) shared.User {
 						Label:       "",
 						CreatedUtc:  "2024-04-04T18:32:47Z",
 						LastUsedUtc: "",
+						Count:       10,
 						Data: shared.BackupCodeData{
 							Count: 10,
 						},

--- a/shared/types.go
+++ b/shared/types.go
@@ -41,9 +41,18 @@ type MfaOption struct {
 	Label       string `json:"label"`
 	CreatedUtc  string `json:"created_utc"`
 	LastUsedUtc string `json:"last_used_utc"`
-	//	Data        struct {
-	//		Count int `json:"count"`
-	//	} `json:"data"`
+	Data        any    `json:"data"`
+}
+
+type WebauthnData struct {
+	ID          int    `json:"id"`
+	Label       string `json:"label"`
+	CreatedUtc  string `json:"created_utc"`
+	LastUsedUtc string `json:"last_used_utc"`
+}
+
+type BackupCodeData struct {
+	Count int `json:"count"`
 }
 
 type Password struct {

--- a/shared/types.go
+++ b/shared/types.go
@@ -1,5 +1,11 @@
 package shared
 
+const (
+	MfaTypeBackupCode = "backupcode"
+	MfaTypeTotp       = "totp"
+	MfaTypeWebauthn   = "webauthn"
+)
+
 // Query is expected payload to lambda function
 type Query struct {
 	Search string
@@ -41,6 +47,7 @@ type MfaOption struct {
 	Label       string `json:"label"`
 	CreatedUtc  string `json:"created_utc"`
 	LastUsedUtc string `json:"last_used_utc"`
+	Count       int    `json:"count"`
 	Data        any    `json:"data"`
 }
 

--- a/shared/types.go
+++ b/shared/types.go
@@ -24,31 +24,41 @@ type User struct {
 	Hide           string   `json:"hide"`
 	RequireMFA     string   `json:"require_mfa"`
 	Member         []string `json:"member"`
-	Mfa            struct {
-		Prompt  string `json:"prompt"`
-		Add     string `json:"add"`
-		Options []struct {
-			ID          int    `json:"id"`
-			Type        string `json:"type"`
-			Label       string `json:"label"`
-			CreatedUtc  string `json:"created_utc"`
-			LastUsedUtc string `json:"last_used_utc"`
-			// Data        struct {
-			// 	Count int `json:"count"`
-			// } `json:"data"`
-		} `json:"options"`
-	} `json:"mfa"`
-	Password struct {
-		CreatedUtc string `json:"created_utc"`
-		ExpiresOn  string `json:"expires_on"`
-	} `json:"password"`
-	Method struct {
-		Add     string `json:"add"`
-		Options []struct {
-			ID       string `json:"id"`
-			Value    string `json:"value"`
-			Verified bool   `json:"verified"`
-			Created  string `json:"created"`
-		} `json:"options"`
-	} `json:"method"`
+	Mfa            Mfa      `json:"mfa"`
+	Password       Password `json:"password"`
+	Method         Method   `json:"method"`
+}
+
+type Mfa struct {
+	Prompt  string      `json:"prompt"`
+	Add     string      `json:"add"`
+	Options []MfaOption `json:"options"`
+}
+
+type MfaOption struct {
+	ID          int    `json:"id"`
+	Type        string `json:"type"`
+	Label       string `json:"label"`
+	CreatedUtc  string `json:"created_utc"`
+	LastUsedUtc string `json:"last_used_utc"`
+	//	Data        struct {
+	//		Count int `json:"count"`
+	//	} `json:"data"`
+}
+
+type Password struct {
+	CreatedUtc string `json:"created_utc"`
+	ExpiresOn  string `json:"expires_on"`
+}
+
+type Method struct {
+	Add     string         `json:"add"`
+	Options []MethodOption `json:"options"`
+}
+
+type MethodOption struct {
+	ID       string `json:"id"`
+	Value    string `json:"value"`
+	Verified bool   `json:"verified"`
+	Created  string `json:"created"`
 }


### PR DESCRIPTION
### Added
- Added a `count` field on `mfa.options[*]` to help the [IdP Support Bot](https://github.com/silinternational/idp-support-bot) print more MFA information.
- Added more detail to the test for `search`

### Changed
- Use `io.ReadAll` instead of deprecated `ioutil.ReadAll`

[IDP-498](https://itse.youtrack.cloud/issue/IDP-498)