### PR TITLE
remove the public-read ACL and add a GetObject policy to the buckets

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,17 +15,6 @@ moved {
   to   = aws_s3_bucket.idp_id_broker_search
 }
 
-resource "aws_s3_bucket_acl" "idp_id_broker_search" {
-  bucket     = aws_s3_bucket.idp_id_broker_search.id
-  acl        = "public-read"
-  depends_on = [aws_s3_bucket_ownership_controls.idp_id_broker_search]
-}
-
-moved {
-  from = aws_s3_bucket_acl.idp-id-broker-search
-  to   = aws_s3_bucket_acl.idp_id_broker_search
-}
-
 resource "aws_s3_bucket_versioning" "idp_id_broker_search" {
   bucket = aws_s3_bucket.idp_id_broker_search.id
   versioning_configuration {
@@ -49,10 +38,29 @@ resource "aws_s3_bucket_ownership_controls" "idp_id_broker_search" {
 
 resource "aws_s3_bucket_public_access_block" "idp_id_broker_search" {
   bucket                  = aws_s3_bucket.idp_id_broker_search.id
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "idp_id_broker_search" {
+  provider = aws.secondary
+
+  bucket = aws_s3_bucket.idp_id_broker_search.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = var.bucket_policy_principals
+        }
+        Action   = "s3:GetObject"
+        Resource = "arn:aws:s3:::${aws_s3_bucket.idp_id_broker_search.bucket}/*"
+      },
+    ]
+  })
 }
 
 // Create a second S3 bucket for uploading binary to a different region (crude form of replication)
@@ -112,10 +120,29 @@ resource "aws_s3_bucket_public_access_block" "idp_id_broker_search_2" {
   provider = aws.secondary
 
   bucket                  = aws_s3_bucket.idp_id_broker_search_2.id
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "idp_id_broker_search_2" {
+  provider = aws.secondary
+
+  bucket = aws_s3_bucket.idp_id_broker_search_2.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = var.bucket_policy_principals
+        }
+        Action   = "s3:GetObject"
+        Resource = "arn:aws:s3:::${aws_s3_bucket.idp_id_broker_search_2.bucket}/*"
+      },
+    ]
+  })
 }
 
 /*

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -80,18 +80,6 @@ moved {
   to   = aws_s3_bucket.idp_id_broker_search_2
 }
 
-resource "aws_s3_bucket_acl" "idp_id_broker_search_2" {
-  provider   = aws.secondary
-  bucket     = aws_s3_bucket.idp_id_broker_search_2.id
-  acl        = "public-read"
-  depends_on = [aws_s3_bucket_ownership_controls.idp_id_broker_search_2]
-}
-
-moved {
-  from = aws_s3_bucket_acl.idp-id-broker-search-2
-  to   = aws_s3_bucket_acl.idp_id_broker_search_2
-}
-
 resource "aws_s3_bucket_versioning" "idp_id_broker_search_2" {
   provider = aws.secondary
   bucket   = aws_s3_bucket.idp_id_broker_search_2.id

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,6 +26,12 @@ variable "aws_secret_key" {
   default = null
 }
 
+variable "bucket_policy_principals" {
+  description = "AWS accounts, users, or policies that are allowed to read objects in the id-broker-search buckets"
+  type        = list(string)
+  default     = []
+}
+
 variable "tags" {
   type    = map(string)
   default = {}


### PR DESCRIPTION
[IDP-1292](https://itse.youtrack.cloud/issue/IDP-1292) push to idp-id-broker-search bucket in us-west-2 broken

### Removed
- Removed public-read ACL because it isn't working as expected.

### Added
- Added a new bucket policy that will allow the necessary access.