### PR TITLE
add public access on checksum files

### DIFF
--- a/build-sign-deploy.sh
+++ b/build-sign-deploy.sh
@@ -11,8 +11,8 @@ openssl dgst -binary -sha256 idp-id-broker-search.zip | base64 --wrap=0 > idp-id
 # Push zip and checksum to S3 under folder for GITHUB_REF_NAME (ex: develop or 1.2.3)
 GITHUB_REF_NAME=${GITHUB_REF_NAME:="unknown"}
 bucket=$DOWNLOAD_BUCKET-${AWS_REGION}
-aws s3 cp --acl public-read idp-id-broker-search.zip s3://$bucket/$GITHUB_REF_NAME/
-aws s3 cp --acl public-read --content-type text/plain idp-id-broker-search.zip.sum s3://$bucket/$GITHUB_REF_NAME/
+aws s3 cp idp-id-broker-search.zip s3://$bucket/$GITHUB_REF_NAME/
+aws s3 cp --content-type text/plain idp-id-broker-search.zip.sum s3://$bucket/$GITHUB_REF_NAME/
 
 if [ -z $AWS_REGION2 ]; then
   exit 0
@@ -20,5 +20,5 @@ fi
 
 export AWS_REGION=${AWS_REGION2}
 bucket=$DOWNLOAD_BUCKET-${AWS_REGION}
-aws s3 cp --acl public-read idp-id-broker-search.zip s3://$bucket/$GITHUB_REF_NAME/
-aws s3 cp --acl public-read --content-type text/plain idp-id-broker-search.zip.sum s3://$bucket/$GITHUB_REF_NAME/
+aws s3 cp idp-id-broker-search.zip s3://$bucket/$GITHUB_REF_NAME/
+aws s3 cp --content-type text/plain idp-id-broker-search.zip.sum s3://$bucket/$GITHUB_REF_NAME/

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,9 +39,9 @@ resource "aws_s3_bucket_ownership_controls" "idp_id_broker_search" {
 resource "aws_s3_bucket_public_access_block" "idp_id_broker_search" {
   bucket                  = aws_s3_bucket.idp_id_broker_search.id
   block_public_acls       = true
-  block_public_policy     = true
+  block_public_policy     = false
   ignore_public_acls      = true
-  restrict_public_buckets = true
+  restrict_public_buckets = false
 }
 
 resource "aws_s3_bucket_policy" "idp_id_broker_search" {
@@ -50,12 +50,22 @@ resource "aws_s3_bucket_policy" "idp_id_broker_search" {
     Version = "2012-10-17",
     Statement = [
       {
+        Sid    = "LimitedAccess"
         Effect = "Allow"
         Principal = {
           AWS = var.bucket_policy_principals
         }
         Action   = "s3:GetObject"
         Resource = "arn:aws:s3:::${aws_s3_bucket.idp_id_broker_search.bucket}/*"
+      },
+      {
+        Sid    = "PublicAccessChecksum"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "s3:GetObject"
+        Resource = "arn:aws:s3:::${aws_s3_bucket.idp_id_broker_search.bucket}/*.sum"
       },
     ]
   })
@@ -107,9 +117,9 @@ resource "aws_s3_bucket_public_access_block" "idp_id_broker_search_2" {
 
   bucket                  = aws_s3_bucket.idp_id_broker_search_2.id
   block_public_acls       = true
-  block_public_policy     = true
+  block_public_policy     = false
   ignore_public_acls      = true
-  restrict_public_buckets = true
+  restrict_public_buckets = false
 }
 
 resource "aws_s3_bucket_policy" "idp_id_broker_search_2" {
@@ -120,12 +130,22 @@ resource "aws_s3_bucket_policy" "idp_id_broker_search_2" {
     Version = "2012-10-17",
     Statement = [
       {
+        Sid    = "LimitedAccess"
         Effect = "Allow"
         Principal = {
           AWS = var.bucket_policy_principals
         }
         Action   = "s3:GetObject"
         Resource = "arn:aws:s3:::${aws_s3_bucket.idp_id_broker_search_2.bucket}/*"
+      },
+      {
+        Sid    = "PublicAccessChecksum"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "s3:GetObject"
+        Resource = "arn:aws:s3:::${aws_s3_bucket.idp_id_broker_search_2.bucket}/*.sum"
       },
     ]
   })


### PR DESCRIPTION
### Changed
- Added a public-read policy statement for the function checksum file. The process that fetches this file is not authenticated, unlike the process that fetches the function zip file. The former uses the http provider and the latter is done within AWS Lambda.