### PR TITLE
upgrade setup-terraform action

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: hashicorp/setup-terraform@v3
+    - uses: hashicorp/setup-terraform@v4
     - run: terraform fmt -check -diff -recursive
     - run: terraform init -backend=false
     - run: terraform validate


### PR DESCRIPTION
[ITSE-2562 Upgrade GitHub Action steps that are using Node 20](https://support.gtis.sil.org/issue/ITSE-2562)

---

### Changed
- Update hashicorp/setup-terraform action to v4 to include support for Node 24. The first round of PRs missed this update.